### PR TITLE
fix: s3cmd install method

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ LABEL maintainer="sebastien.pondichy@gmail.com"
 COPY /scripts /scripts
 
 RUN apk --no-cache add \
-    python3 \
-    py3-pip \
-    && pip3 install s3cmd \
+	s3cmd
+#    python3 \
+#    py3-pip \
+#    && pip3 install s3cmd \
     && chmod u+x /scripts/gitea-backup.sh \
     && mkdir -p /etc/s3cmd


### PR DESCRIPTION
All python packages must now be installed in a virtual environment to
avoid error this environment is externally managed. See PEP 668 for the
detailed specification. As s3cmd is available as a standard alpine
package, let's use this installation method instead as it will be more
reliable.
